### PR TITLE
fix memory (mem_buff) related problem

### DIFF
--- a/raspberrypi/usr/src/epicon/epicon.c
+++ b/raspberrypi/usr/src/epicon/epicon.c
@@ -40,7 +40,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #include "epicon.h"
 
-extern long int *mem_buff;          /* external memory buffer */
+extern char *mem_buff;              /* external memory buffer */
 char esc[2] = { ESC, '\0' };        /* escape charctor */
 extern pid_t ck_pid;                /* check to process id */
 char *LOG_file = '\0';              /* console log file */
@@ -99,6 +99,7 @@ sigtype end_process()
   if (LOG_flag) fclose(LOG_fp);
   unlink(Epicon_Socket);
   free(mem_buff);
+  mem_buff = NULL;
   if (ck_pid && !Quiet_flag) fprintf(stderr, "\r\nDisconnected\r\n");
   exit(0);
 }

--- a/raspberrypi/usr/src/epicon/epicon_main.c
+++ b/raspberrypi/usr/src/epicon/epicon_main.c
@@ -67,7 +67,8 @@ extern unsigned int CR_delay;   /* external send CR delay value */
 extern char Epicon_Socket[128]; /* AF_UNIX socket for Communication of parents & child */
 void win_size_update();         /* windows size send for telnet */
 void display_console();         /* open message */
-long int incount,outcount,*mem_buff;
+char *mem_buff = NULL;          /* external memory buffer */
+long int incount,outcount;
 int speed;
 int fp1,fp2;
 int pg_flag,fp4;
@@ -575,8 +576,7 @@ void epicon_main()
     }
   }
   incount = outcount = fp4 = 0;
-  mem_buff = malloc(MSIZE*sizeof(char));
-  memset( mem_buff, (int)'\0', sizeof( mem_buff));
+  mem_buff = calloc(MSIZE, sizeof(char));
   if ( mem_buff == NULL) {
     fprintf(stderr,"Memory not get!! about memory 10M less");
     end_process();


### PR DESCRIPTION
(for details see commit message)
Tested on Linux(Debian11-testing, Raspberry Pi Desktop and Arch Linux), NetBSD and OpenBSD.

I think that avoiding double-call end_process() at epicon.c is important, but there is no enough time to investigate. Radical cure will be needed as future task.