### PR TITLE
IPv6 support

### DIFF
--- a/raspberrypi/usr/src/epicon/epicon.h
+++ b/raspberrypi/usr/src/epicon/epicon.h
@@ -46,6 +46,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <arpa/telnet.h>
 #include <arpa/inet.h>
 #include <termios.h>
+#include <netdb.h>
 // #include <curses.h> 2017.4.20 remove
 // #include <term.h> 2017.4.20 remove
 #define R_WSIZE 1024                /* send file block size */


### PR DESCRIPTION
**not need now**, but I want to make a proposal for future epicon enhancement.
this PR extends -n option like this:

  -n 127.0.0.1:80 (IPv4 address and port)
  -n 2001:db8::1.80 (IPv6 address and port)
  -n localhost:80 (name and port)

and, -4 (IPv4 only) and -6 (IPv6 only) option is also added.