### PR TITLE
revise lock/pid file directory

### DIFF
--- a/raspberrypi/usr/src/epicon/epicon.c
+++ b/raspberrypi/usr/src/epicon/epicon.c
@@ -118,7 +118,7 @@ char *argv[];
   extern int optind;
   extern int getopt(), convert_speed(), escape_code(), access(), convert_mode();
   epicon_pid = getpid();
-  sprintf( Epicon_Socket ,"%s%ld",Epicon_Socket_init , epicon_pid);
+  sprintf( Epicon_Socket ,"%s%ld", VAR_PREFIX Epicon_Socket_init, epicon_pid);
   unlink( Epicon_Socket );
   strcpy(com_port, COMPORT);
   argv_redirect = argv[argc];

--- a/raspberrypi/usr/src/epicon/epicon.h
+++ b/raspberrypi/usr/src/epicon/epicon.h
@@ -67,7 +67,11 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #define sigtype int
 #endif
 #define DAY "compiled:"__DATE__
-#define Epicon_Socket_init "/var/run/lock/epicon_socket." /* AF_UNIX socket */
-#define VAR_LOCK "/var/run/lock/"
-#define TTY_LOCK "/var/run/lock/LCK.."
+#if defined(__linux__)
+#define VAR_PREFIX "/var/run/lock/"
+#else
+#define VAR_PREFIX "/var/tmp/"
+#endif
+#define Epicon_Socket_init "epicon_socket." /* AF_UNIX socket */
+#define TTY_LOCK "LCK.."
 #define MY_TTYPE  "vt100"  /* terminal type */

--- a/raspberrypi/usr/src/epicon/epicon_uty.c
+++ b/raspberrypi/usr/src/epicon/epicon_uty.c
@@ -169,11 +169,11 @@ int com_port_unuse(char *com)
   fl.l_start  = 0;        /* Offset from l_whence         */
   fl.l_len    = 0;        /* length, 0 = to EOF           */
   fl.l_pid    = getpid(); /* our PID                      */
-  fd = open(VAR_LOCK, O_RDONLY);
+  fd = open(VAR_PREFIX, O_RDONLY);
   if( fd < 0 ) return 1;
   close(fd);
   p = strrchr(com, '/');
-  strcpy(file, TTY_LOCK);
+  strcpy(file, VAR_PREFIX TTY_LOCK);
   if( p ) strcat(file, p + 1);
   else  {
     strcat(file, com);
@@ -264,11 +264,11 @@ int com_port_use_check(char *com)
   fl.l_start  = 0;        /* Offset from l_whence         */
   fl.l_len    = 0;        /* length, 0 = to EOF           */
   fl.l_pid    = getpid(); /* our PID                      */
-  fd = open(VAR_LOCK, O_RDONLY);
+  fd = open(VAR_PREFIX, O_RDONLY);
   if( fd < 0 ) return 1;
   close(fd);
   p = strrchr(com, '/');
-  strcpy(file, TTY_LOCK);
+  strcpy(file, VAR_PREFIX TTY_LOCK);
   if( p ) strcat(file, p + 1);
   else  {
     strcat(file, com);


### PR DESCRIPTION
Moving Epicon_Socket_init from /var/tmp to /var/run/lock is no problem
on Linux, but this makes problem on NetBSD/OpenBSD.
epicon cannot send binary file (with ~f command) under these OSes.

specifying VAR_LOCK, TTY_LOCK and Epicon_Socket_init is now resssembled with
VAR_PREFIX, TTY_LOCK and Epicon_Socket_init.
now TTY_LOCK and Epicon_Socket_init requires VAR_PREFIX.