### PR TITLE
fix "did you forget to '#include <time.h>"'? problem

### DIFF
--- a/raspberrypi/usr/src/epicon/epicon.h
+++ b/raspberrypi/usr/src/epicon/epicon.h
@@ -37,6 +37,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <setjmp.h>
 #include <sys/wait.h>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
#27 (add timestamp feature) related problem.
Linux needs <time.h> for struct tm.

modern gcc tells that:
 ../epicon_uty.c:47:1: note: 'localtime' is defined in header '<time.h>'; did you forget to '#include <time.h>'?
so add proper include to epicon.h, sorry.
